### PR TITLE
[8.0] Lost file attachments for products

### DIFF
--- a/openerp/addons/base/migrations/8.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/8.0.1.3/pre-migration.py
@@ -56,3 +56,13 @@ def migrate(cr, version):
         SET res_model = 'stock.picking'
         WHERE res_model in ('stock.picking.in', 'stock.picking.out');
         """)
+    
+    # Product.template is used for non variant product in v7 this was
+    # product.product
+    openupgrade.logged_query(
+        cr, """
+        UPDATE ir_attachment
+        SET res_model = 'product.template'
+        WHERE res_model = 'product.product';
+        """)
+    


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
An attachment has been saved to a product but is not available after the upgrade to odoo v8

Current behavior before PR:
attachment is not available in v8 in a product form

Desired behavior after PR is merged:
Attachment is available

To find the correct attachment files the id and table name are searched. This causes missing attachment because table names have changed
V7: product form -> product.product
       product variant (unsupported module?)
V8: product form -> product.template
      product variant form-> product.template

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pra